### PR TITLE
gunicorn 버전을 20.1에서 22.0으로 상향

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy~=1.22.2
 flask~=2.0.3
 apscheduler~=3.9.1
-gunicorn~=20.1.0
+gunicorn>=22.0.0


### PR DESCRIPTION
## Summary
- 보안상의 권고로 gunicorn 버전을 20.1에서 22.0으로 상향합니다.
- https://github.com/sim-so/semantle-jp/security/dependabot/2