### PR TITLE
fix: change an order to push correct answer to guesses

### DIFF
--- a/static/assets/js/semantle.js
+++ b/static/assets/js/semantle.js
@@ -94,7 +94,7 @@ function getUpdateTimeHours() {
     return midnightUtc.getHours();
 }
 
-function solveStory(guesses, puzzleNumber, winState, hints_used) {
+function solveStory(guesses, puzzleNumber, winState) {
     let guess_count = guesses.length;
     let winOrGiveUp = 'ギブアップ';
     if (winState == 1) {

--- a/static/assets/js/semantle.js
+++ b/static/assets/js/semantle.js
@@ -94,12 +94,11 @@ function getUpdateTimeHours() {
     return midnightUtc.getHours();
 }
 
-function solveStory(guesses, puzzleNumber) {
-    let guess_count = guesses.length - 1;
+function solveStory(guesses, puzzleNumber, winState, hints_used) {
+    let guess_count = guesses.length;
     let winOrGiveUp = 'ギブアップ';
-    if (storage.getItem("winState") == 1) {
+    if (winState == 1) {
         winOrGiveUp = '正解!';
-        guess_count += 1
         if (guess_count == 1) {
             return `お見事です!初答えでパズル${puzzleNumber}の正解に当てました! https://semantoru.com/`;
         }
@@ -114,23 +113,23 @@ function solveStory(guesses, puzzleNumber) {
             out += ` (ランク ${percentile})`;
         }
         return out;
-    }
+    };
 
     let time = storage.getItem('endTime') - storage.getItem('startTime');
     let timeFormatted = new Date(time).toISOString().substr(11, 8).replace(":", "h").replace(":", "m");
-    let timeInfo = `所要時間: ${timeFormatted}秒\n`
+    let timeInfo = `所要時間: ${timeFormatted}秒\n`;
     if (time > 24 * 3600000) {
-        timeInfo = '所要時間: 24時間\n 以上'
+        timeInfo = '所要時間: 24時間\n 以上';
     }
     if (!shareTime) {
-        timeInfo = ''
+        timeInfo = '';
     }
 
-    let topGuessMsg = ''
+    let topGuessMsg = '';
     const topGuesses = guesses.slice();
     if (shareTopGuess) {
         topGuesses.sort(function(a, b){return b[0]-a[0]});
-        const topGuess = topGuesses[1];
+        const topGuess = topGuesses[0];
         let [similarity, old_guess, percentile, guess_number] = topGuess;
         topGuessMsg = `最高類似度: ${describe(similarity, percentile)}\n`;
     }
@@ -150,13 +149,13 @@ function solveStory(guesses, puzzleNumber) {
             }
         }
         if (element[2] <= 10) {
-            numTop10 += 1
+            numTop10 += 1;
         }
         if (element[2] <= 100) {
-            numTop100 += 1
+            numTop100 += 1;
         }
         if (element[2] <= 1000) {
-            numTop1000 += 1
+            numTop1000 += 1;
         }
     }
 
@@ -205,10 +204,6 @@ let Semantle = (function() {
             return false;
         }
 
-        if (guessData.sim == 1 && !gameOver) {
-            endGame(true, true);
-        }
-
         cache[guess] = guessData;
 
         let percentile = guessData.rank;
@@ -232,6 +227,10 @@ let Semantle = (function() {
             }
         }
         guesses.sort(function(a, b){return b[0]-a[0]});
+
+        if (guessData.sim == 1 && !gameOver) {
+            endGame(true, true);
+        }
 
         if (!gameOver) {
             saveGame(-1, -1);


### PR DESCRIPTION
## Summary
- #10 
- 최종 결과 화면과 공유 메시지 중 추측횟수에 정답 단어를 제출한 경우가 포함되지 않는 문제가 있었습니다.
### Cause
- 공유 메시지를 생성하는 `SolveStory` 함수 내에서 guesses 변수에 정답 단어를 추가하는 동작이 정상적으로 작동하지 않았습니다.
- 또한, 게임을 종료시키면서 결과 메시지를 출력하는 `endGame` 함수 내 혹은 해당 함수 호출 이전에 guesses 변수에 정답 단어를 추가하는 동작이 없었습니다.
### Fix
- `endGame` 함수 호출 위치를 제출한 단어를 `guesses`에 push한 다음 시점으로 옮겼습니다.
- 이에 따라, `endGame`에서 결과 출력 메시지와 공유 메시지를 생성할 때 정답을 제출한 횟수가 포함되고, `SolveStory` 함수 내에서 추측횟수를 계산하기 위한 별도의 동작이 필요 없어졌습니다.

## Additional
- 코드 내 누락되어 있던 세미콜론을 추가했습니다.
---
## Summary
- #10 
- The guess count showed on the final results screen and the shared message did not include a final guess.
### Cause
- Within the `SolveStory` function that generates the shared message, the code of adding the correct word to the guesses variable was not working correctly.
- Additionally, there was no code to add a final guess to the `guesses` within the `endGame` function or before calling the function, which ends the game and outputs a result message.
### Fix
- Moved the location of the `endGame` function call to the point after pushing the submitted word into `guesses`.
- This ensures that when `endGame` generates the resulting output and share message, it includes the number of correct answers submitted. It also eliminates the need for a separate behavior within the `SolveStory` function to count the number of guesses.

## Additional
- Added a semicolon that was missing in the code.